### PR TITLE
feat: improve graphviz socket handling

### DIFF
--- a/src/__tests__/GraphViz.test.tsx
+++ b/src/__tests__/GraphViz.test.tsx
@@ -1,13 +1,23 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import GraphViz from '../components/GraphViz'
 
+const handlers: Record<string, Function> = {}
 jest.mock('socket.io-client', () => {
-  return () => ({ on: jest.fn(), emit: jest.fn(), disconnect: jest.fn() })
+  return () => ({
+    on: (event: string, cb: Function) => {
+      handlers[event] = cb
+    },
+    emit: jest.fn(),
+    disconnect: jest.fn()
+  })
 })
 
-global.fetch = jest.fn(() =>
-  Promise.resolve({ json: () => Promise.resolve({ nodes: [], links: [] }) })
-) as any
+beforeEach(() => {
+  ;(global.fetch as any) = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ nodes: [], links: [] }) })
+  )
+  Object.keys(handlers).forEach((k) => delete handlers[k])
+})
 
 global.Worker = class {
   postMessage() {}
@@ -18,4 +28,20 @@ test('renders search input', async () => {
   render(<GraphViz />)
   const input = await screen.findByPlaceholderText(/Search/i)
   expect(input).toBeInTheDocument()
+})
+
+test('shows error when fetch fails', async () => {
+  ;(global.fetch as any) = jest.fn(() => Promise.reject(new Error('fail')))
+  render(<GraphViz />)
+  const error = await screen.findByText(/Failed to load graph/i)
+  expect(error).toBeInTheDocument()
+})
+
+test('handles socket connection errors', async () => {
+  render(<GraphViz />)
+  act(() => {
+    handlers['connect_error'] && handlers['connect_error']()
+  })
+  const error = await screen.findByText(/Socket connection lost/i)
+  expect(error).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- debounce incoming `graph-update` socket events and handle reconnects
- add tests for fetch failure and socket connection errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891555d33908323b286e36f52097111