### PR TITLE
feat: git management and agent patch UI

### DIFF
--- a/backend/services/gitService.js
+++ b/backend/services/gitService.js
@@ -1,0 +1,95 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { exec } = require('child_process');
+const axios = require('axios');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function resolveSafe(relPath = '') {
+  const fullPath = path.resolve(repoRoot, relPath);
+  if (!fullPath.startsWith(repoRoot)) {
+    throw new Error('Invalid path');
+  }
+  return fullPath;
+}
+
+async function listTree(relPath = '') {
+  const dirPath = resolveSafe(relPath);
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const result = [];
+  for (const entry of entries) {
+    if (entry.name === '.git') continue;
+    const entryRel = path.join(relPath, entry.name);
+    if (entry.isDirectory()) {
+      result.push({
+        name: entry.name,
+        path: entryRel,
+        type: 'dir',
+        children: await listTree(entryRel)
+      });
+    } else {
+      result.push({ name: entry.name, path: entryRel, type: 'file' });
+    }
+  }
+  return result;
+}
+
+async function readFile(relPath) {
+  const filePath = resolveSafe(relPath);
+  const data = await fs.readFile(filePath, 'utf8');
+  return data.replace(/\r\n/g, '\n');
+}
+
+async function writeFile(relPath, content) {
+  const filePath = resolveSafe(relPath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content.replace(/\r\n/g, '\n'), 'utf8');
+}
+
+function runGit(args) {
+  return new Promise((resolve, reject) => {
+    exec(`git ${args}`, { cwd: repoRoot }, (err, stdout, stderr) => {
+      if (err) return reject(new Error(stderr.trim() || err.message));
+      resolve(stdout.trim());
+    });
+  });
+}
+
+async function commit(message) {
+  await runGit('add .');
+  return await runGit(`commit -m "${message.replace(/"/g, '\\"')}"`);
+}
+
+async function branch(name) {
+  return await runGit(`checkout -b ${name}`);
+}
+
+async function push(remote, branchName) {
+  return await runGit(`push ${remote} ${branchName}`);
+}
+
+async function createPullRequest({ title, body, head, base }) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN not set');
+  const remoteUrl = await runGit('config --get remote.origin.url');
+  const match = remoteUrl.match(/github.com[:\/](.+?)\/(.+)\.git/);
+  if (!match) throw new Error('Cannot parse remote URL');
+  const [_, owner, repo] = match;
+  const url = `https://api.github.com/repos/${owner}/${repo}/pulls`;
+  const response = await axios.post(
+    url,
+    { title, body, head, base },
+    { headers: { Authorization: `token ${token}`, 'User-Agent': 'graphrag-bot' } }
+  );
+  return response.data;
+}
+
+module.exports = {
+  listTree,
+  readFile,
+  writeFile,
+  commit,
+  branch,
+  push,
+  createPullRequest
+};

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -1,11 +1,22 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 
 import FileExplorer from '@/components/workspace/FileExplorer'
+import MarkdownEditor from '@/components/workspace/MarkdownEditor'
 import { WorkspaceProvider } from '@/workspace/WorkspaceCtx'
 
 export default function WorkspacePage() {
+  const [content, setContent] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/files/get?path=README.md')
+      .then((r) => r.json())
+      .then((d) => setContent(d.content))
+      .catch((e) => console.error('Failed to load file', e))
+  }, [])
+
   return (
     <WorkspaceProvider>
       <div className="h-screen">
@@ -15,7 +26,9 @@ export default function WorkspacePage() {
           </Panel>
           <PanelResizeHandle className="w-1 bg-gray-700" />
           <Panel defaultSize={60}>
-            <div className="p-2">Editor Tabs</div>
+            {content !== null && (
+              <MarkdownEditor path="README.md" value={content} onChange={setContent} />
+            )}
           </Panel>
           <PanelResizeHandle className="w-1 bg-gray-700" />
           <Panel defaultSize={20} minSize={10}>

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -4,14 +4,39 @@ import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import CodeEditor from './CodeEditor';
+import DiffView from './DiffView';
 
 interface MarkdownEditorProps {
   value: string;
+  path: string;
   onChange?: (value: string) => void;
 }
 
-export default function MarkdownEditor({ value, onChange }: MarkdownEditorProps) {
+export default function MarkdownEditor({ value, path, onChange }: MarkdownEditorProps) {
   const [view, setView] = useState<'editor' | 'preview'>('editor');
+  const [agentOpen, setAgentOpen] = useState(false);
+  const [agentContent, setAgentContent] = useState('');
+
+  const askAgent = async () => {
+    const instruction = prompt('Instruction for agent?') || '';
+    try {
+      const res = await fetch('/api/agent/patch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path, content: value, instruction })
+      });
+      const data = await res.json();
+      setAgentContent(data.payload);
+      setAgentOpen(true);
+    } catch (err) {
+      console.error('Agent patch failed', err);
+    }
+  };
+
+  const applyPatch = () => {
+    onChange?.(agentContent);
+    setAgentOpen(false);
+  };
 
   return (
     <div className="h-full flex flex-col">
@@ -30,6 +55,9 @@ export default function MarkdownEditor({ value, onChange }: MarkdownEditorProps)
         >
           Preview
         </button>
+        <button type="button" onClick={askAgent}>
+          Ask Agent
+        </button>
       </div>
       <div className="flex-1 overflow-auto">
         {view === 'editor' ? (
@@ -44,6 +72,21 @@ export default function MarkdownEditor({ value, onChange }: MarkdownEditorProps)
           </div>
         )}
       </div>
+      {agentOpen && (
+        <div className="fixed right-0 top-0 h-full w-1/3 bg-white shadow-lg flex flex-col">
+          <div className="flex-1 overflow-auto">
+            <DiffView original={value} modified={agentContent} language="markdown" />
+          </div>
+          <div className="p-2 border-t flex justify-end space-x-2">
+            <button type="button" onClick={() => setAgentOpen(false)}>
+              Close
+            </button>
+            <button type="button" onClick={applyPatch}>
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add backend git service with tree, file, commit, branch, push and PR routes
- expose agent patch endpoint and client drawer to apply suggestions
- display README in workspace editor with Ask Agent support

## Testing
- `npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689599fc23e883238c6ce86ff0b8cc6c