### PR TITLE
docs: enrich POML directory descriptions

### DIFF
--- a/backend/README.poml
+++ b/backend/README.poml
@@ -1,0 +1,25 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Backend Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Document backend services')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="services/README.poml" />
+    <document src="tests/README.poml" />
+    <document src="logs/README.poml" />
+    <document src="app.js" />
+    <document src="unified-dmp-server.js" />
+    <document src="test-server.js" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Summarize the Node.js backend. Mention that <code>app.js</code> bootstraps an Express server, <code>unified-dmp-server.js</code> exposes combined routes, and <code>test-server.js</code> provides a lightweight server for tests. Note that <code>services</code> contains git and agent helpers, <code>tests</code> holds unit and integration tests, and <code>logs</code> stores runtime logs.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/backend/logs/README.poml
+++ b/backend/logs/README.poml
@@ -1,0 +1,20 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Backend Logs')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe backend logging output')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="backend.log" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Explain that <code>backend.log</code> captures server output to help trace API requests and diagnose failures.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/backend/services/README.poml
+++ b/backend/services/README.poml
@@ -1,0 +1,25 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Backend Services')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe backend utility services')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="gitService.js" />
+    <document src="multiAgentService.js" />
+    <document src="pythonProxy.js" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Describe each service module:
+      - <code>gitService.js</code> offers file operations and Git commands like listTree, readFile, writeFile, commit, branch, push, and createPullRequest.
+      - <code>multiAgentService.js</code> initializes default LLM agents and manages conversations through methods such as initialize, createConversation, and sendMessage.
+      - <code>pythonProxy.js</code> forwards HTTP requests to the Python backend with retry and error handling.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/backend/tests/README.poml
+++ b/backend/tests/README.poml
@@ -1,0 +1,21 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Backend Tests')}}" %}
+  {% set user_goal = "{{user_goal|default('Explain backend test suite')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="agents.test.js" />
+    <document src="test_integration.py" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Summarize the backend test suite. <code>agents.test.js</code> exercises the MultiAgentService API, while <code>test_integration.py</code> verifies cross-language calls into the Python Intellisense service.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/dmp-intellisense-source/README.poml
+++ b/dmp-intellisense-source/README.poml
@@ -1,0 +1,22 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('DMP Intellisense Source')}}" %}
+  {% set user_goal = "{{user_goal|default('Explain Python-based Intellisense core')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="scripts/README.poml" />
+    <document src="src/README.poml" />
+    <document src="run.py" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Summarize the Python Flask-based Intellisense service. Mention <code>run.py</code> as the entrypoint, <code>scripts/start_app.sh</code> for launching, and modules like <code>agents.py</code> for <code>AgentService</code>, <code>graph.py</code> for <code>GraphService</code>, and <code>routes.py</code> exposing REST endpoints.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/dmp-intellisense-source/scripts/README.poml
+++ b/dmp-intellisense-source/scripts/README.poml
@@ -1,0 +1,20 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Intellisense Scripts')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe helper scripts for Intellisense')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="start_app.sh" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Describe <code>start_app.sh</code>, which activates the Python environment and runs the Flask app.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/dmp-intellisense-source/src/README.poml
+++ b/dmp-intellisense-source/src/README.poml
@@ -1,0 +1,25 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Intellisense Source Code')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe Python modules providing Intellisense')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="agents.py" />
+    <document src="graph.py" />
+    <document src="routes.py" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Detail the Python modules:
+      - <code>agents.py</code> defines <code>AgentService</code> with <code>process_message</code>.
+      - <code>graph.py</code> implements <code>GraphService</code> with <code>add_node</code>, <code>add_edge</code>, <code>query_node</code>, and <code>export_graph</code>.
+      - <code>routes.py</code> registers Flask blueprints for <code>/graph</code> and <code>/chat</code> endpoints.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/frontend/README.poml
+++ b/frontend/README.poml
@@ -1,0 +1,15 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Frontend Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe frontend assets')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Placeholder for future standalone frontend assets; current application code lives under <code>src</code>.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/outputs/README.poml
+++ b/outputs/README.poml
@@ -1,0 +1,20 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Outputs Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe generated output files')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="gap_analyzer_errors.log" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Document generated artifacts. <code>gap_analyzer_errors.log</code> records issues encountered by gap analyzers.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/public/README.poml
+++ b/public/README.poml
@@ -1,0 +1,15 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Public Assets')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe static assets exposed by Next.js')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Document static assets served by Next.js: <code>file.svg</code>, <code>globe.svg</code>, <code>next.svg</code>, <code>vercel.svg</code>, and <code>window.svg</code>.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/scripts/README.poml
+++ b/scripts/README.poml
@@ -1,0 +1,20 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Scripts Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Explain repository utility scripts')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="setup.ts" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Describe <code>setup.ts</code>, which installs dependencies and prepares local configuration for the workspace.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/src/README.poml
+++ b/src/README.poml
@@ -1,0 +1,24 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Source Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe frontend application source')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="app/README.poml" />
+    <document src="components/README.poml" />
+    <document src="lib/README.poml" />
+    <document src="workspace/README.poml" />
+    <document src="__tests__/README.poml" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Summarize the Next.js application's source code. Note that <code>app/</code> defines routes and layouts, <code>components/</code> houses UI elements like chat and graph visualizations, <code>lib/api.ts</code> wraps backend calls, and <code>workspace/</code> implements a client-side coding environment built with BrowserFS. Mention that the codebase is written in TypeScript.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/src/__tests__/README.poml
+++ b/src/__tests__/README.poml
@@ -1,0 +1,20 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Source Tests')}}" %}
+  {% set user_goal = "{{user_goal|default('Summarize frontend test coverage')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="GraphViz.test.tsx" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Describe the Jest tests for frontend components. <code>GraphViz.test.tsx</code> ensures the GraphViz renderer initializes and handles graph data correctly.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/src/app/README.poml
+++ b/src/app/README.poml
@@ -1,0 +1,22 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('App Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe Next.js app routes and pages')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="page.tsx" />
+    <document src="layout.tsx" />
+    <document src="api/graph/route.ts" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Detail the Next.js application structure. <code>layout.tsx</code> defines the root layout, <code>page.tsx</code> renders the main dashboard, and the <code>api/</code> directory exposes route handlers such as <code>api/graph/route.ts</code> for graph queries alongside agent, git, and file APIs.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/src/components/README.poml
+++ b/src/components/README.poml
@@ -1,0 +1,22 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Components Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Document reusable UI components')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="DMPChatInterface.tsx" />
+    <document src="GraphViz.tsx" />
+    <document src="workspace/README.poml" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Summarize reusable UI components. Highlight chat interfaces, graph visualizers (e.g., <code>GraphViz.tsx</code>, <code>D3ForceKnowledgeGraph.tsx</code>), model management panels, quick action cards, and workspace tools.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/src/components/workspace/README.poml
+++ b/src/components/workspace/README.poml
@@ -1,0 +1,25 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Workspace Components')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe code editor and workspace UI parts')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="CodeEditor.tsx" />
+    <document src="CommandBar.tsx" />
+    <document src="DiffView.tsx" />
+    <document src="EditorTabs.tsx" />
+    <document src="FileExplorer.tsx" />
+    <document src="MarkdownEditor.tsx" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Outline the workspace UI components: <code>CodeEditor.tsx</code> wraps Monaco, <code>CommandBar.tsx</code> exposes actions, <code>DiffView.tsx</code> shows file changes, <code>EditorTabs.tsx</code> manages open files, <code>FileExplorer.tsx</code> navigates the virtual FS, and <code>MarkdownEditor.tsx</code> renders markdown.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/src/lib/README.poml
+++ b/src/lib/README.poml
@@ -1,0 +1,20 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Lib Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Explain shared utilities and API helpers')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="api.ts" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Describe shared utilities. <code>api.ts</code> wraps fetch calls to backend endpoints for agents, graph data, git operations, and file storage.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/src/workspace/README.poml
+++ b/src/workspace/README.poml
@@ -1,0 +1,21 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Workspace Directory')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe client-side workspace logic')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="WorkspaceCtx.tsx" />
+    <document src="fs/README.poml" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Summarize state management and virtual file system utilities enabling the interactive workspace. Mention that <code>WorkspaceCtx.tsx</code> provides React context for open files and that the nested <code>fs</code> module supplies BrowserFS-based storage.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/src/workspace/fs/README.poml
+++ b/src/workspace/fs/README.poml
@@ -1,0 +1,20 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('Workspace FS')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe browser-based file system utilities')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="BrowserFS.ts" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Explain that <code>BrowserFS.ts</code> wraps the BrowserFS library to provide an IndexedDB-backed file system abstraction used by the workspace.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>

--- a/workspace.poml
+++ b/workspace.poml
@@ -1,0 +1,26 @@
+<poml>
+<parameters>
+  {% set project_name = "{{project_name|default('GraphRAG Multi-Agent Workspace')}}" %}
+  {% set user_goal = "{{user_goal|default('Describe repository structure')}}" %}
+  {% set variant = "{{variant|default('default')}}" %}
+</parameters>
+<system>
+  <context>
+    <document src="backend/README.poml" />
+    <document src="frontend/README.poml" />
+    <document src="dmp-intellisense-source/README.poml" />
+    <document src="src/README.poml" />
+    <document src="scripts/README.poml" />
+    <document src="outputs/README.poml" />
+    <document src="public/README.poml" />
+  </context>
+</system>
+<task name="main" enabled="true">
+  <role name="assistant">
+    <instructions>
+      Provide an overview of {{project_name}}. Note that the workspace combines a TypeScript/Next.js frontend in <code>src</code>, a Node.js Express API in <code>backend</code>, and a Python Flask Intellisense service in <code>dmp-intellisense-source</code>. Mention that <code>scripts</code> holds setup utilities, <code>public</code> exposes static assets, and <code>outputs</code> captures runtime logs. Summarize the role of each referenced subdirectory.
+    </instructions>
+    <output-format>text</output-format>
+  </role>
+</task>
+</poml>


### PR DESCRIPTION
## Summary
- expand `workspace.poml` to describe frontend, backend, and Python Intellisense pieces
- document key files and functions in each directory-specific POML

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0da9d02288323bf46a0be3ca62dac